### PR TITLE
(fix): Replace IEnumerable for a List data type

### DIFF
--- a/src/Domain/Dish.cs
+++ b/src/Domain/Dish.cs
@@ -5,7 +5,7 @@ public record Dish
 {
     public long ID { get; set; }
     public string? Name { get; set; }
-    public IEnumerable<Product>? Ingredients { get; set; }
+    public List<Product>? Ingredients { get; set; }
     public double Price { get; set; }
     public TimeSpan AverageCompletionTime { get; set; }
     public int Difficulty { get; set; }

--- a/src/Domain/Inventory.cs
+++ b/src/Domain/Inventory.cs
@@ -4,7 +4,7 @@
 public record Inventory
 {
     public long ID { get; set; }
-    public IEnumerable<InventoryItem>? items { get; set; }
+    public List<InventoryItem>? items { get; set; }
     public DateOnly CompletionDate { get; set; }
     public int ToTalUnits { get; set; }
     public double TotalInventoryPrice { get; set; }

--- a/src/Domain/Menu.cs
+++ b/src/Domain/Menu.cs
@@ -6,6 +6,6 @@ public record Menu
 {
     public long ID { get; set; }
     public string? Name { get; set; }
-    public IEnumerable<Dish>? Dishes { get; set; }
+    public List<Dish>? Dishes { get; set; }
     public char Status { get; set; }
 }

--- a/src/Domain/Order.cs
+++ b/src/Domain/Order.cs
@@ -4,7 +4,7 @@ namespace Domain;
 public record Order
 {
     public long ID { get; set; }
-    public IEnumerable<Dish>? Dishes { get; set; }
+    public List<Dish>? Dishes { get; set; }
     public double SubTotal { get; set; }
     public double Tax { get; set; }
     public char Status { get; set; }


### PR DESCRIPTION
The `IEnumerable` data type is replaced by `List` in order to have access to the concrete methods in a direct way than having to convert to to a List the collection. 

I.E:
An `IEnumerable` object or parameter to have access to the `Add` method should be converted first to `List`.

```c#
private IEnumerable DataCollection;

public myClass() //Constructor
{
     DataCollection = new();
}

public myMethod(Model model)
{
     DataCollection.ToList().Add(model); //This part require the `ToList` part to access to the `Add` method.
}
```
With the concrete data type.
```c#
private List DataCollection;

public myClass() //Constructor
{
     DataCollection = new();
}

public myMethod(Model model)
{
     DataCollection.Add(model); //Have direct access and avoid issues.
}
```